### PR TITLE
Stopped using shakacode's eslint and went straight for airbnb

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 ---
 parser: babel-eslint
 
-extends: eslint-config-shakacode
+extends: eslint-config-airbnb
 
 plugins:
   - react
@@ -49,3 +49,5 @@ rules:
   react/self-closing-comp: 2
   react/sort-comp: 0                                                            # Should be 1. `statics` should be on top.
   react/wrap-multilines: 2
+  react/jsx-filename-extension: 0
+  react/no-unused-prop-types: [2, {skipShapeProps: true}]

--- a/package.json
+++ b/package.json
@@ -20,14 +20,9 @@
     "redux-thunk": "2.1.0"
   },
   "devDependencies": {
-    "babel-eslint": "^6.1.2",
     "babel-jest": "^15.0.0",
     "babel-preset-react-native": "^1.9.0",
-    "eslint": "^3.1.1",
-    "eslint-config-shakacode": "^5.0.0",
-    "eslint-plugin-import": "^1.11.1",
-    "eslint-plugin-jsx-a11y": "^2.0.1",
-    "eslint-plugin-react": "^5.2.2",
+    "eslint-config-airbnb": "^11.1.0",
     "jest": "^15.1.1",
     "jest-react-native": "^15.0.0",
     "react-test-renderer": "^15.3.1"


### PR DESCRIPTION
Shakacodes was out of date and throwing all manner of errors.
Airbnb appears to be better, if a little more strict.
