### PR TITLE
Fixed an issue where swiped tasks wouldn't appear in correct lists

### DIFF
--- a/app/components/TaskList.js
+++ b/app/components/TaskList.js
@@ -69,6 +69,7 @@ export default class TaskList extends Component {
   renderRow(task) {
     return (
       <Task
+        key={`${task.id}-${task.type}`}
         id={task.id}
         title={task.title}
         timestamp={task.timestamp}


### PR DESCRIPTION
By added a compound key (made up of the id and the type) the list
correctly flushed the list between types.
